### PR TITLE
Use Leiningen's exit routine only with non-zero exit code

### DIFF
--- a/src/leiningen/tach.clj
+++ b/src/leiningen/tach.clj
@@ -89,7 +89,8 @@
 (defn exit
   [code message]
   (println message)
-  (main/exit code))
+  (if-not (zero? code)
+    (main/exit code)))
 
 (defn tach
   [project & args]


### PR DESCRIPTION
Calling exit with zero exit code does not play well with `lein with-profile ...`.
The problem is that Leiningen in that case takes a different code path
and throws internally:
https://github.com/technomancy/leiningen/blob/178f99bf0d8b2a2812187c08be9d08536871e1d9/leiningen-core/src/leiningen/core/main.clj#L159

And that exception is later simply treated as error:
https://github.com/technomancy/leiningen/blob/178f99bf0d8b2a2812187c08be9d08536871e1d9/src/leiningen/with_profile.clj#L54