### PR TITLE
Handle cljsbuild build maps

### DIFF
--- a/src/leiningen/tach.clj
+++ b/src/leiningen/tach.clj
@@ -49,9 +49,13 @@
   [project args]
   (let [builds (get-in project [:cljsbuild :builds])]
     (if-some [build-id (second args)]
-      (first (filter (fn [build]
-                       (= (:id build) build-id))
-                     builds))
+      (or (first (filter (fn [build]
+                           (= (:id build) build-id))
+                         builds))
+          (->> builds
+               (filter (fn [[id _]] (= (name id) build-id)))
+               first
+               second))
       (first builds))))
 
 (defn filtered-classpath


### PR DESCRIPTION
The current implementation of get-build is able to filter only when the format
of :builds is in the vector + :id form. This patch handles the nested map
specification.