### PR TITLE
Making it possible to invoke the planck repl, via a new :repl option,…

### DIFF
--- a/test/leiningen/tach_test.clj
+++ b/test/leiningen/tach_test.clj
@@ -172,3 +172,18 @@
   (is (tach/tach-verbose? tach-verbose))
   (is (not (tach/tach-verbose? tach-not-verbose)))
   (is (= [execution-env "-v"] (take 2 (tach/build-command-line tach-verbose [execution-env]))))))
+
+(deftest tach-repl?-test
+  (let [tach-repl {:tach {:repl true :test-runner-ns 'com.some.ns}}
+        tach-no-repl {:tach {:test-runner-ns 'com.some.ns}}
+        planck-env "planck"
+        lumo-env "lumo"
+        eval-arg "-e"]
+    (is (tach/tach-repl? tach-repl))
+    (is (not (tach/tach-repl? tach-no-repl)))
+    ; repl means we should not have the -e (evaluate) arg for planck
+    (is (nil? (some #{eval-arg} (tach/build-command-line tach-repl [planck-env]))))
+    ; no :repl means we should
+    (is (not (nil? (some #{eval-arg} (tach/build-command-line tach-no-repl [planck-env])))))
+    ; :repl option should be ignored for lumo env
+    (is (not (nil? (some #{eval-arg} (tach/build-command-line tach-repl [lumo-env])))))))


### PR DESCRIPTION
… which will simply not pass the eval parameter

The idea is that it can be useful to have the REPL when debugging test failures.

I can also add a test of this change against the built-up command line, preferably on top of my other change here: https://github.com/mfikes/tach/pull/13/files#diff-763c372e97ea08d283da3d739bf688b255fc4e90e74e22f01864f3c9a03b1fa0R168